### PR TITLE
feat(web): restore shadcn dark mode switcher

### DIFF
--- a/apps/web/src/components/mode-toggle.tsx
+++ b/apps/web/src/components/mode-toggle.tsx
@@ -1,0 +1,61 @@
+import { Check, Laptop, Moon, Sun } from 'lucide-react'
+
+import {
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuSub,
+	DropdownMenuSubContent,
+	DropdownMenuSubTrigger,
+} from '@auxarmory/ui/components/ui/dropdown-menu'
+
+import { useTheme } from './theme-provider'
+
+const themeDisplayName = {
+	light: 'Light',
+	dark: 'Dark',
+	system: 'System',
+} as const
+
+export function ModeToggle() {
+	const { theme, setTheme } = useTheme()
+
+	return (
+		<>
+			<DropdownMenuSeparator />
+			<DropdownMenuSub>
+				<DropdownMenuSubTrigger>
+					{theme === 'dark' ? <Moon /> : null}
+					{theme === 'light' ? <Sun /> : null}
+					{theme === 'system' ? <Laptop /> : null}
+					Theme
+					<span className='ml-auto text-xs text-muted-foreground'>
+						{themeDisplayName[theme]}
+					</span>
+				</DropdownMenuSubTrigger>
+				<DropdownMenuSubContent>
+					<DropdownMenuItem onClick={() => setTheme('light')}>
+						<Sun />
+						Light
+						{theme === 'light' ? (
+							<Check className='ml-auto' />
+						) : null}
+					</DropdownMenuItem>
+					<DropdownMenuItem onClick={() => setTheme('dark')}>
+						<Moon />
+						Dark
+						{theme === 'dark' ? (
+							<Check className='ml-auto' />
+						) : null}
+					</DropdownMenuItem>
+					<DropdownMenuItem onClick={() => setTheme('system')}>
+						<Laptop />
+						System
+						{theme === 'system' ? (
+							<Check className='ml-auto' />
+						) : null}
+					</DropdownMenuItem>
+				</DropdownMenuSubContent>
+			</DropdownMenuSub>
+		</>
+	)
+}

--- a/apps/web/src/components/nav-user.tsx
+++ b/apps/web/src/components/nav-user.tsx
@@ -31,6 +31,7 @@ import {
 
 import { authClient } from '../lib/auth-client'
 import { getUserInitial } from '../lib/user'
+import { ModeToggle } from './mode-toggle'
 
 export function NavUser() {
 	const { isMobile } = useSidebar()
@@ -135,6 +136,7 @@ export function NavUser() {
 								Notifications
 							</DropdownMenuItem>
 						</DropdownMenuGroup>
+						<ModeToggle />
 						<DropdownMenuSeparator />
 						<DropdownMenuItem onClick={handleAuthClick}>
 							<LogOut />

--- a/apps/web/src/components/theme-provider.tsx
+++ b/apps/web/src/components/theme-provider.tsx
@@ -1,0 +1,97 @@
+import type { ReactNode } from 'react'
+import { createContext, useContext, useEffect, useMemo, useState } from 'react'
+
+type Theme = 'dark' | 'light' | 'system'
+
+interface ThemeProviderProps {
+	children: ReactNode
+	defaultTheme?: Theme
+	storageKey?: string
+}
+
+interface ThemeProviderState {
+	theme: Theme
+	setTheme: (theme: Theme) => void
+}
+
+const ThemeProviderContext = createContext<ThemeProviderState | undefined>(
+	undefined,
+)
+
+export function ThemeProvider({
+	children,
+	defaultTheme = 'system',
+	storageKey = 'vite-ui-theme',
+}: ThemeProviderProps) {
+	const [theme, setTheme] = useState<Theme>(() => {
+		if (typeof window === 'undefined') {
+			return defaultTheme
+		}
+
+		const storedTheme = window.localStorage.getItem(
+			storageKey,
+		) as Theme | null
+		return storedTheme ?? defaultTheme
+	})
+
+	useEffect(() => {
+		const root = window.document.documentElement
+
+		const applyTheme = () => {
+			root.classList.remove('light', 'dark')
+
+			if (theme === 'system') {
+				const systemTheme = window.matchMedia(
+					'(prefers-color-scheme: dark)',
+				).matches
+					? 'dark'
+					: 'light'
+				root.classList.add(systemTheme)
+				return
+			}
+
+			root.classList.add(theme)
+		}
+
+		applyTheme()
+
+		if (theme !== 'system') {
+			return
+		}
+
+		const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+		const handleChange = () => applyTheme()
+		mediaQuery.addEventListener('change', handleChange)
+
+		return () => {
+			mediaQuery.removeEventListener('change', handleChange)
+		}
+	}, [theme])
+
+	const value = useMemo(
+		() => ({
+			theme,
+			setTheme: (nextTheme: Theme) => {
+				window.localStorage.setItem(storageKey, nextTheme)
+				setTheme(nextTheme)
+			},
+		}),
+		[theme, storageKey],
+	)
+
+	return (
+		<ThemeProviderContext.Provider value={value}>
+			{children}
+		</ThemeProviderContext.Provider>
+	)
+}
+
+export function useTheme() {
+	const context = useContext(ThemeProviderContext)
+
+	if (context === undefined) {
+		throw new Error('useTheme must be used within a ThemeProvider')
+	}
+
+	return context
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -8,6 +8,7 @@ import type { AppRouter } from '@auxarmory/api/routers'
 import { env } from './env'
 import { TRPCProvider } from './lib/trpc'
 import { routeTree } from './routeTree.gen'
+import { ThemeProvider } from './components/theme-provider'
 
 function makeQueryClient() {
 	return new QueryClient({
@@ -62,11 +63,16 @@ export function getRouter() {
 		defaultPreload: 'intent',
 		defaultPreloadStaleTime: 0,
 		Wrap: ({ children }) => (
-			<QueryClientProvider client={queryClient}>
-				<TRPCProvider trpcClient={trpcClient} queryClient={queryClient}>
-					{children}
-				</TRPCProvider>
-			</QueryClientProvider>
+			<ThemeProvider defaultTheme='system' storageKey='vite-ui-theme'>
+				<QueryClientProvider client={queryClient}>
+					<TRPCProvider
+						trpcClient={trpcClient}
+						queryClient={queryClient}
+					>
+						{children}
+					</TRPCProvider>
+				</QueryClientProvider>
+			</ThemeProvider>
 		),
 	})
 

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -46,7 +46,7 @@ export const Route = createRootRouteWithContext<RouterAppContext>()({
 
 function RootDocument({ children }: { children: React.ReactNode }) {
 	return (
-		<html lang='en'>
+		<html lang='en' suppressHydrationWarning>
 			<head>
 				<HeadContent />
 			</head>

--- a/apps/web/test/components/theme-provider.test.tsx
+++ b/apps/web/test/components/theme-provider.test.tsx
@@ -1,0 +1,109 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ThemeProvider, useTheme } from '../../src/components/theme-provider'
+
+function ThemeControls() {
+	const { setTheme } = useTheme()
+
+	return (
+		<div>
+			<button type='button' onClick={() => setTheme('dark')}>
+				Set dark
+			</button>
+			<button type='button' onClick={() => setTheme('light')}>
+				Set light
+			</button>
+		</div>
+	)
+}
+
+describe('ThemeProvider', () => {
+	beforeEach(() => {
+		window.localStorage.clear()
+		document.documentElement.classList.remove('light', 'dark')
+	})
+
+	it('applies stored theme from localStorage', async () => {
+		window.localStorage.setItem('vite-ui-theme', 'dark')
+
+		render(
+			<ThemeProvider>
+				<div>content</div>
+			</ThemeProvider>,
+		)
+
+		await waitFor(() => {
+			expect(document.documentElement).toHaveClass('dark')
+		})
+		expect(document.documentElement).not.toHaveClass('light')
+	})
+
+	it('updates theme class and persists when setTheme is called', async () => {
+		render(
+			<ThemeProvider>
+				<ThemeControls />
+			</ThemeProvider>,
+		)
+
+		fireEvent.click(screen.getByRole('button', { name: /set dark/i }))
+
+		await waitFor(() => {
+			expect(document.documentElement).toHaveClass('dark')
+		})
+		expect(window.localStorage.getItem('vite-ui-theme')).toBe('dark')
+
+		fireEvent.click(screen.getByRole('button', { name: /set light/i }))
+
+		await waitFor(() => {
+			expect(document.documentElement).toHaveClass('light')
+		})
+		expect(document.documentElement).not.toHaveClass('dark')
+		expect(window.localStorage.getItem('vite-ui-theme')).toBe('light')
+	})
+
+	it('uses system preference and reacts to system theme changes', async () => {
+		let prefersDark = true
+		let changeHandler: ((event: MediaQueryListEvent) => void) | undefined
+
+		Object.defineProperty(window, 'matchMedia', {
+			writable: true,
+			value: vi.fn(() => ({
+				get matches() {
+					return prefersDark
+				},
+				media: '(prefers-color-scheme: dark)',
+				onchange: null,
+				addListener: () => undefined,
+				removeListener: () => undefined,
+				addEventListener: (_: string, handler: EventListener) => {
+					changeHandler = handler as unknown as (
+						event: MediaQueryListEvent,
+					) => void
+				},
+				removeEventListener: () => {
+					changeHandler = undefined
+				},
+				dispatchEvent: () => true,
+			})),
+		})
+
+		render(
+			<ThemeProvider defaultTheme='system'>
+				<div>content</div>
+			</ThemeProvider>,
+		)
+
+		await waitFor(() => {
+			expect(document.documentElement).toHaveClass('dark')
+		})
+
+		prefersDark = false
+		changeHandler?.({ matches: false } as MediaQueryListEvent)
+
+		await waitFor(() => {
+			expect(document.documentElement).toHaveClass('light')
+		})
+		expect(document.documentElement).not.toHaveClass('dark')
+	})
+})


### PR DESCRIPTION
## Summary
- Reintroduce runtime theme management in the web app with a `ThemeProvider` that applies `light`/`dark` classes, persists preference to localStorage, and follows system theme changes.
- Add a user-facing theme submenu in the account dropdown so users can switch between Light, Dark, and System modes from the authenticated shell.
- Wire the provider at the app root, add hydration-safe root HTML handling, and include component tests that verify persistence and class application behavior.

## Testing
- pnpm --filter @auxarmory/web test
- pnpm --filter @auxarmory/web build