### PR TITLE
feat(battlenet): add unwrap errors with rich request context

### DIFF
--- a/packages/battlenet/AGENTS.md
+++ b/packages/battlenet/AGENTS.md
@@ -1,0 +1,9 @@
+# @auxarmory/battlenet
+
+Always unwrap client responses.
+
+Use `const data = unwrap(await client.wow.SomeEndpoint(...))`.
+
+`unwrap` returns `data` on success.
+`unwrap` throws `BattlenetZodUnwrapError` for zod failures with `context.request` and `context.response`.
+`unwrap` throws `BattlenetUnwrapError` for all other failures with `errorType` and full context.

--- a/packages/battlenet/src/index.ts
+++ b/packages/battlenet/src/index.ts
@@ -1,10 +1,11 @@
 import type { z } from 'zod/v4'
 
-import type { ClientReturn, RegionsEnum } from './types'
+import type { ClientRequestContext, ClientReturn, RegionsEnum } from './types'
 import { ApplicationAuthResponse, BattlenetError } from './types'
 import { WoWGameDataClient, WoWProfileClient } from './wow'
 
 export * from './util'
+export * from './unwrap'
 
 type Regions = z.infer<typeof RegionsEnum>
 
@@ -21,6 +22,27 @@ interface BaseRequestOptions<T> {
 	namespace?: 'static' | 'dynamic' | 'profile'
 	authorization: string
 	zod: z.Schema<T>
+}
+
+function paramsToContextObject(params: URLSearchParams) {
+	const result: Record<string, string | string[]> = {}
+
+	for (const [key, value] of params.entries()) {
+		const current = result[key]
+		if (current == null) {
+			result[key] = value
+			continue
+		}
+
+		if (Array.isArray(current)) {
+			current.push(value)
+			continue
+		}
+
+		result[key] = [current, value]
+	}
+
+	return result
 }
 
 class BaseClient {
@@ -56,6 +78,14 @@ class BaseClient {
 
 		if (params.size > 0) {
 			url.search = params.toString()
+		}
+
+		const requestContext: ClientRequestContext = {
+			endpoint,
+			method,
+			namespace,
+			url: url.toString(),
+			params: paramsToContextObject(params),
 		}
 
 		const headers: Record<string, string> = {
@@ -94,6 +124,7 @@ class BaseClient {
 						`Empty response: ${res.status} ${res.statusText}`,
 					),
 					raw_data: {} as T,
+					request_context: requestContext,
 				}
 			}
 			if (parseError) {
@@ -104,6 +135,7 @@ class BaseClient {
 						`Invalid JSON response: ${res.status} ${res.statusText}`,
 					),
 					raw_data: {} as T,
+					request_context: requestContext,
 				}
 			}
 			const { data, success, error } = zod.safeParse(parsedJson)
@@ -113,6 +145,7 @@ class BaseClient {
 						success: true,
 						data: parsedJson as T,
 						raw_data: parsedJson as T,
+						request_context: requestContext,
 					}
 				}
 
@@ -126,12 +159,14 @@ class BaseClient {
 					error: error,
 					error_type: 'zod',
 					raw_data: parsedJson as T,
+					request_context: requestContext,
 				}
 			}
 			return {
 				success: true,
 				data,
 				raw_data: parsedJson as T,
+				request_context: requestContext,
 			}
 		}
 
@@ -141,6 +176,7 @@ class BaseClient {
 				error_type: 'auth',
 				error: res,
 				raw_data: {} as T,
+				request_context: requestContext,
 			}
 		}
 
@@ -150,6 +186,7 @@ class BaseClient {
 				error_type: 'unknown',
 				error: new Error(`Response ${res.status} ${res.statusText}`),
 				raw_data: {} as T,
+				request_context: requestContext,
 			}
 		}
 
@@ -160,6 +197,7 @@ class BaseClient {
 				error_type: 'battlenet',
 				error: data,
 				raw_data: parsedJson as T,
+				request_context: requestContext,
 			}
 		}
 		return {
@@ -167,6 +205,7 @@ class BaseClient {
 			error_type: 'unknown',
 			error: new Error(`Unknown error: ${res.status} ${res.statusText}`),
 			raw_data: parsedJson as T,
+			request_context: requestContext,
 		}
 	}
 }

--- a/packages/battlenet/src/tests/unwrap.test.ts
+++ b/packages/battlenet/src/tests/unwrap.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod/v4'
+
+import { BattlenetUnwrapError, BattlenetZodUnwrapError, unwrap } from '..'
+
+describe('unwrap', () => {
+	it('returns data for successful responses', () => {
+		const result = unwrap({
+			success: true,
+			data: { id: 42 },
+			raw_data: { id: 42 },
+			request_context: {
+				endpoint: 'data/wow/test',
+				method: 'GET',
+				namespace: 'static',
+				url: 'https://eu.api.blizzard.com/data/wow/test?locale=en_US',
+				params: { locale: 'en_US' },
+			},
+		})
+
+		expect(result).toEqual({ id: 42 })
+	})
+
+	it('throws a zod unwrap error with request and response context', () => {
+		const parsed = z.object({ id: z.number() }).safeParse({ id: 'bad' })
+		if (parsed.success) {
+			throw new Error('Expected zod parse to fail for test setup')
+		}
+
+		expect(() =>
+			unwrap({
+				success: false,
+				error_type: 'zod',
+				error: parsed.error,
+				raw_data: { id: 'bad' } as never,
+				request_context: {
+					endpoint: 'profile/wow/character/realm/name',
+					method: 'GET',
+					namespace: 'profile',
+					url: 'https://eu.api.blizzard.com/profile/wow/character/realm/name?namespace=profile-eu&locale=en_US',
+					params: { namespace: 'profile-eu', locale: 'en_US' },
+				},
+			}),
+		).toThrowError(BattlenetZodUnwrapError)
+
+		try {
+			unwrap({
+				success: false,
+				error_type: 'zod',
+				error: parsed.error,
+				raw_data: { id: 'bad' } as never,
+				request_context: {
+					endpoint: 'profile/wow/character/realm/name',
+					method: 'GET',
+					namespace: 'profile',
+					url: 'https://eu.api.blizzard.com/profile/wow/character/realm/name?namespace=profile-eu&locale=en_US',
+					params: { namespace: 'profile-eu', locale: 'en_US' },
+				},
+			})
+		} catch (error) {
+			expect(error).toBeInstanceOf(BattlenetZodUnwrapError)
+			const zodError = error as BattlenetZodUnwrapError
+			expect(zodError.context.request.params).toEqual({
+				namespace: 'profile-eu',
+				locale: 'en_US',
+			})
+			expect(zodError.context.response).toEqual({ id: 'bad' })
+		}
+	})
+
+	it('throws a generic unwrap error for non-zod failures', () => {
+		expect(() =>
+			unwrap({
+				success: false,
+				error_type: 'unknown',
+				error: new Error('Request failed'),
+				raw_data: {} as never,
+				request_context: {
+					endpoint: 'data/wow/item/19019',
+					method: 'GET',
+					namespace: 'static',
+					url: 'https://eu.api.blizzard.com/data/wow/item/19019?namespace=static-eu&locale=en_US',
+					params: { namespace: 'static-eu', locale: 'en_US' },
+				},
+			}),
+		).toThrowError(BattlenetUnwrapError)
+	})
+})

--- a/packages/battlenet/src/types.ts
+++ b/packages/battlenet/src/types.ts
@@ -4,13 +4,29 @@ import type { BattlenetError } from './validators'
 
 export * from './validators'
 
+export interface ClientRequestContext {
+	endpoint: string
+	method: 'POST' | 'GET'
+	namespace?: 'static' | 'dynamic' | 'profile'
+	url: string
+	params: Record<string, string | string[]>
+}
+
 export type ClientReturn<T> =
-	| { success: true; data: T; raw_data: T; error?: never; error_type?: never }
+	| {
+			success: true
+			data: T
+			raw_data: T
+			request_context: ClientRequestContext
+			error?: never
+			error_type?: never
+	  }
 	| {
 			success: false
 			error: ZodError<T>
 			error_type: 'zod'
 			raw_data: T
+			request_context: ClientRequestContext
 			data?: never
 	  }
 	| {
@@ -18,6 +34,7 @@ export type ClientReturn<T> =
 			error: Response
 			error_type: 'auth'
 			raw_data: T
+			request_context: ClientRequestContext
 			data?: never
 	  }
 	| {
@@ -25,6 +42,7 @@ export type ClientReturn<T> =
 			error: z.infer<typeof BattlenetError>
 			error_type: 'battlenet'
 			raw_data: T
+			request_context: ClientRequestContext
 			data?: never
 	  }
 	| {
@@ -32,5 +50,6 @@ export type ClientReturn<T> =
 			error: Error
 			error_type: 'unknown'
 			raw_data: T
+			request_context: ClientRequestContext
 			data?: never
 	  }

--- a/packages/battlenet/src/unwrap.ts
+++ b/packages/battlenet/src/unwrap.ts
@@ -1,0 +1,96 @@
+import type { ClientRequestContext, ClientReturn } from './types'
+
+const MAX_PREVIEW_LENGTH = 2000
+
+interface UnwrapErrorContext {
+	request: ClientRequestContext
+	response: unknown
+	error: unknown
+}
+
+function stringifyWithLimit(value: unknown, maxLength = MAX_PREVIEW_LENGTH) {
+	let serialized: string
+
+	try {
+		serialized = JSON.stringify(value)
+	} catch {
+		serialized = JSON.stringify(String(value))
+	}
+
+	if (serialized.length <= maxLength) {
+		return serialized
+	}
+
+	return `${serialized.slice(0, maxLength)}... [truncated]`
+}
+
+export class BattlenetUnwrapError extends Error {
+	public readonly errorType: 'zod' | 'auth' | 'battlenet' | 'unknown'
+	public readonly context: UnwrapErrorContext
+
+	constructor(
+		message: string,
+		options: {
+			errorType: 'zod' | 'auth' | 'battlenet' | 'unknown'
+			context: UnwrapErrorContext
+			cause: unknown
+		},
+	) {
+		super(message, { cause: options.cause })
+		this.name = 'BattlenetUnwrapError'
+		this.errorType = options.errorType
+		this.context = options.context
+	}
+}
+
+export class BattlenetZodUnwrapError extends BattlenetUnwrapError {
+	constructor(
+		message: string,
+		options: {
+			context: UnwrapErrorContext
+			cause: unknown
+		},
+	) {
+		super(message, {
+			errorType: 'zod',
+			context: options.context,
+			cause: options.cause,
+		})
+		this.name = 'BattlenetZodUnwrapError'
+	}
+}
+
+export function unwrap<T>(response: ClientReturn<T>): T {
+	if (response.success) {
+		return response.data
+	}
+
+	const context: UnwrapErrorContext = {
+		request: response.request_context,
+		response: response.raw_data,
+		error: response.error,
+	}
+
+	if (response.error_type === 'zod') {
+		const paramsPreview = stringifyWithLimit(
+			response.request_context.params,
+		)
+		const responsePreview = stringifyWithLimit(response.raw_data)
+		throw new BattlenetZodUnwrapError(
+			`Battle.net response failed schema validation for ${response.request_context.endpoint}; params=${paramsPreview}; response=${responsePreview}`,
+			{
+				context,
+				cause: response.error,
+			},
+		)
+	}
+
+	throw new BattlenetUnwrapError(
+		`Battle.net request failed with ${response.error_type} error for ${response.request_context.endpoint}`,
+		{
+			errorType: response.error_type,
+			context,
+			cause: response.error,
+		},
+	)
+}

--- a/packages/battlenet/src/wow/game_data/pvp_season.ts
+++ b/packages/battlenet/src/wow/game_data/pvp_season.ts
@@ -48,6 +48,7 @@ export async function PvPSeason(this: WoWGameDataClient, pvpSeasonId: number) {
 			success: true,
 			data: null,
 			raw_data: null,
+			request_context: ret.request_context,
 		}
 	}
 


### PR DESCRIPTION
## Summary
- add a generic `unwrap` helper for battlenet client responses that returns typed data or throws structured errors
- include `request_context` (endpoint, namespace, URL, params) on all `ClientReturn` variants and preserve it in special-case flows
- add focused tests for unwrap behavior and a minimal `AGENTS.md` usage note centered on unwrap

## Verification
- pnpm build (packages/battlenet)
- pnpm vitest run src/tests/unwrap.test.ts --config vitest.config.ts
- full battlenet test suite still requires Battle.net credentials in env