### PR TITLE
feat(db): add prisma-style database reset command

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -10,6 +10,8 @@
     "db:generate": "pnpm --dir ../.. exec drizzle-kit generate --config drizzle.config.ts",
     "db:migrate": "pnpm --dir ../.. exec drizzle-kit migrate --config drizzle.config.ts",
     "db:migrate:test": "DATABASE_URL=${DATABASE_URL_TEST:-$DATABASE_URL} pnpm --dir ../.. exec drizzle-kit migrate --config drizzle.config.ts",
+    "db:reset": "node ./scripts/reset.mjs && pnpm run db:migrate",
+    "db:reset:test": "DATABASE_URL=${DATABASE_URL_TEST:-$DATABASE_URL} pnpm run db:reset",
     "db:sync": "pnpm --dir ../.. exec drizzle-kit push --config drizzle.config.ts",
     "db:sync:test": "DATABASE_URL=${DATABASE_URL_TEST:-$DATABASE_URL} pnpm --dir ../.. exec drizzle-kit push --config drizzle.config.ts",
     "db:push": "pnpm --dir ../.. exec drizzle-kit push --config drizzle.config.ts"

--- a/packages/db/scripts/reset.mjs
+++ b/packages/db/scripts/reset.mjs
@@ -1,0 +1,55 @@
+import process from 'node:process'
+import readline from 'node:readline/promises'
+
+import pg from 'pg'
+
+const HELP_FLAGS = new Set(['-h', '--help'])
+const FORCE_FLAGS = new Set(['-f', '--force'])
+const args = new Set(process.argv.slice(2))
+
+if ([...HELP_FLAGS].some((flag) => args.has(flag))) {
+	console.log('Usage: pnpm --filter @auxarmory/db db:reset [-- --force]')
+	console.log('Drops and recreates schema "public", then re-runs migrations.')
+	process.exit(0)
+}
+
+const databaseUrl = process.env.DATABASE_URL
+
+if (!databaseUrl) {
+	console.error('DATABASE_URL is required to reset the database')
+	process.exit(1)
+}
+
+const forced = [...FORCE_FLAGS].some((flag) => args.has(flag))
+const isInteractive = process.stdin.isTTY && process.stdout.isTTY
+
+if (!forced && isInteractive) {
+	const rl = readline.createInterface({
+		input: process.stdin,
+		output: process.stdout,
+	})
+
+	const answer = await rl.question(
+		'Are you sure you want to reset the database? All data will be lost. (y/N) ',
+	)
+	rl.close()
+
+	if (!['y', 'yes'].includes(answer.trim().toLowerCase())) {
+		console.log('Database reset cancelled.')
+		process.exit(0)
+	}
+}
+
+const { Client } = pg
+const client = new Client({ connectionString: databaseUrl })
+
+try {
+	await client.connect()
+	await client.query('DROP SCHEMA IF EXISTS public CASCADE;')
+	await client.query('CREATE SCHEMA public;')
+	await client.query('GRANT ALL ON SCHEMA public TO CURRENT_USER;')
+	await client.query('GRANT ALL ON SCHEMA public TO public;')
+	console.log('Database schema reset complete.')
+} finally {
+	await client.end()
+}


### PR DESCRIPTION
## Summary
- add `db:reset` and `db:reset:test` scripts in `@auxarmory/db` to provide a Prisma-like reset workflow
- implement `packages/db/scripts/reset.mjs` to drop and recreate the `public` schema before running migrations
- include interactive safety confirmation with `--force` support for CI/non-interactive usage